### PR TITLE
wifi_statistics: Fix compatibility with Linux 4.3

### DIFF
--- a/average.h
+++ b/average.h
@@ -1,0 +1,72 @@
+/* Copyright (C) 2015-2016 Johannes Berg
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of version 2 of the GNU General Public
+ * License as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <http://www.gnu.org/licenses/>.
+ *
+ * This file contains macros for maintaining compatibility with older versions
+ * of the Linux kernel.
+ */
+
+#ifndef _WIFI_STATISTICS_COMPAT_LINUX_AVERAGE_H
+#define _WIFI_STATISTICS_COMPAT_LINUX_AVERAGE_H
+
+#include <linux/version.h>
+#include_next <linux/average.h>
+
+#include <linux/bug.h>
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 3, 0)
+
+/* Exponentially weighted moving average (EWMA) */
+
+#define DECLARE_EWMA(name, _factor, _weight)				\
+	struct ewma_##name {						\
+		unsigned long internal;					\
+	};								\
+	static inline void ewma_##name##_init(struct ewma_##name *e)	\
+	{								\
+		BUILD_BUG_ON(!__builtin_constant_p(_factor));		\
+		BUILD_BUG_ON(!__builtin_constant_p(_weight));		\
+		BUILD_BUG_ON_NOT_POWER_OF_2(_factor);			\
+		BUILD_BUG_ON_NOT_POWER_OF_2(_weight);			\
+		e->internal = 0;					\
+	}								\
+	static inline unsigned long					\
+	ewma_##name##_read(struct ewma_##name *e)			\
+	{								\
+		BUILD_BUG_ON(!__builtin_constant_p(_factor));		\
+		BUILD_BUG_ON(!__builtin_constant_p(_weight));		\
+		BUILD_BUG_ON_NOT_POWER_OF_2(_factor);			\
+		BUILD_BUG_ON_NOT_POWER_OF_2(_weight);			\
+		return e->internal >> ilog2(_factor);			\
+	}								\
+	static inline void ewma_##name##_add(struct ewma_##name *e,	\
+					     unsigned long val)		\
+	{								\
+		unsigned long internal = ACCESS_ONCE(e->internal);	\
+		unsigned long weight = ilog2(_weight);			\
+		unsigned long factor = ilog2(_factor);			\
+									\
+		BUILD_BUG_ON(!__builtin_constant_p(_factor));		\
+		BUILD_BUG_ON(!__builtin_constant_p(_weight));		\
+		BUILD_BUG_ON_NOT_POWER_OF_2(_factor);			\
+		BUILD_BUG_ON_NOT_POWER_OF_2(_weight);			\
+									\
+		ACCESS_ONCE(e->internal) = internal ?			\
+			(((internal << weight) - internal) +		\
+				(val << factor)) >> weight :		\
+			(val << factor);				\
+	}
+
+#endif /* < KERNEL_VERSION(4, 3, 0) */
+
+#endif /* _WIFI_STATISTICS_COMPAT_LINUX_AVERAGE_H */

--- a/station.c
+++ b/station.c
@@ -30,7 +30,7 @@ void ws_sta_init_detail(struct ws_sta_detailed *detail)
 {
 	detail->min = INT_MAX;
 	detail->max = INT_MIN;
-	ewma_init(&detail->ewma, WS_EWMA_FACTOR, WS_EWMA_WEIGHT);
+	ewma_ewma_init(&detail->ewma);
 }
 
 void ws_sta_init(struct ws_sta *ws_sta)
@@ -61,7 +61,7 @@ static void ws_sta_print_detail(struct seq_file *seq,
 	seq_printf(seq, "%s\t\"sum_square\": %llu,\n", tabs,
 		   detail->sum_square);
 	seq_printf(seq, "%s\t\"ewma\": %d\n", tabs,
-		   (int)(ewma_read(&detail->ewma) - (INT_MAX>>2)));
+		   (int)(ewma_ewma_read(&detail->ewma) - (INT_MAX>>2)));
 	seq_printf(seq, "%s}", tabs);
 }
 
@@ -148,7 +148,7 @@ static void ws_sta_detailed_apply(struct ws_sta_detailed *detail, int value)
 	detail->count++;
 	detail->sum += value;
 	detail->sum_square += ((u64) value) * ((u64) value);
-	ewma_add(&detail->ewma, value + (INT_MAX>>2));
+	ewma_ewma_add(&detail->ewma, value + (INT_MAX>>2));
 }
 
 int ws_sta_general(struct ws_sta *ws_sta, struct sk_buff *skb)

--- a/wifi_statistics.h
+++ b/wifi_statistics.h
@@ -29,6 +29,7 @@
 #include <linux/average.h>
 #include <net/cfg80211.h>
 #include <net/ieee80211_radiotap.h>
+#include "average.h"
 #include "compat.h"		/* remove if sending this upstream */
 
 #define WIFI_STATS_DRIVER_AUTHOR  "Simon Wunderlich <sw@simonwunderlich.de>"
@@ -44,10 +45,12 @@
 #define BCAST_TID		NUM_UCAST_TID
 #define NUM_TIDS		(NUM_UCAST_TID + 1)
 
+DECLARE_EWMA(ewma, WS_EWMA_FACTOR, WS_EWMA_WEIGHT)
+
 struct ws_sta_detailed {
 	int last, min, max, count, sum;
 	u64 sum_square;
-	struct ewma ewma;
+	struct ewma_ewma ewma;
 };
 
 enum ws_sta_type {


### PR DESCRIPTION
The ewma functions were replaced with a template-like system to automatically generate optimized versions for each type. A compatibility version of this implementation is provided for older kernel versions